### PR TITLE
Fix: Question 4 solution references wrong person

### DIFF
--- a/src/en/2-1-1-exercise.md
+++ b/src/en/2-1-1-exercise.md
@@ -367,7 +367,7 @@ scope TaxComputation:
 
   definition person2_dead_before_processing_date equals
     # Another possible syntax for testing patterns
-    couple.person_1.date_of_death with pattern
+    couple.person_2.date_of_death with pattern
       Deceased content d and d < processing_date
 ```
 ~~~

--- a/src/fr/2-1-1-exercise.md
+++ b/src/fr/2-1-1-exercise.md
@@ -365,7 +365,7 @@ champ d'application CalculImpôt:
 
   définition personne2_décédée_avant_date_traitement égal à
     # Une autre syntaxe possible pour tester les motifs
-    couple.personne_1.date_décès sous forme
+    couple.personne_2.date_décès sous forme
       Décédé contenu d et d < date_traitement
 ```
 ~~~


### PR DESCRIPTION
Fixed Question 4 solution which incorrectly referenced `couple.person_1` instead of `couple.person_2` for the `person2_dead_before_processing_date` variable