### PR TITLE
Fix: Article 4 implementation to a less than (<) condition

### DIFF
--- a/src/en/2-2-conditionals-exceptions.md
+++ b/src/en/2-2-conditionals-exceptions.md
@@ -173,7 +173,9 @@ at article 1.
 ```catala-code-en
 scope IncomeTaxComputation:
   exception definition tax_rate
-  under condition individual.income < $10,000
+  under condition individual.income <= $10,000
+  # Notice the <= above, the wording in article 4 might suggest < but
+  # we always take the interpretation most favorable to the taxpayer!
   consequence equals 0 %
 ```
 ~~~

--- a/src/fr/2-2-conditionals-exceptions.md
+++ b/src/fr/2-2-conditionals-exceptions.md
@@ -173,7 +173,10 @@ Les individus gagnant moins de 10 000 € sont exonérés de l'impôt sur le rev
 ```catala-code-fr
 champ d'application CalculImpôtRevenu:
   exception définition taux_imposition
-  sous condition individu.revenu < 10 000 €
+  sous condition individu.revenu <= 10 000 €
+  # Notez le <= au-dessus, la formulation de l'article 4 suggère d'utiliser <
+  # mais nous prenons toujours l'interprétation la plus favorable au
+  # contribuable !
   conséquence égal à 0 %
 ```
 ~~~


### PR DESCRIPTION
The regulation states "Individuals earning less than $10,000" but the code used `<= $10,000`. Changed to `< $10,000` to match the specification text.