### PR TITLE
one deployment per PR

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -38,7 +38,7 @@ jobs:
         run: |
           cat > wrangler.jsonc <<'JSON'
           {
-            "name": "catala-book-preview",
+            "name": "catala-book-preview-pr-${{ github.event.pull_request.number }}",
             "compatibility_date": "2025-04-01",
             "workers_dev": true,
             "preview_urls": true,

--- a/.github/workflows/preview_cleanup.yml
+++ b/.github/workflows/preview_cleanup.yml
@@ -1,0 +1,20 @@
+name: Cleanup Preview Deployment
+
+on:
+  pull_request_target:
+    types: [closed]
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Delete preview worker
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          wranglerVersion: 4.21.0
+          command: delete catala-book-preview-pr-${{ github.event.pull_request.number }}


### PR DESCRIPTION
Deploy one preview website per PR rather than a global one (was simpler but with multiple concurrent PRs, it's too limited)