### PR TITLE
Suggestion for modules documentations

### DIFF
--- a/src/en/5-6-modules.md
+++ b/src/en/5-6-modules.md
@@ -30,7 +30,16 @@ you will not be able to call functions of this file from other modules.
 
 ## Imports
 
-Modules can "use" other modules to import their **public** types, scopes and constants. If you want to use module `Bar` inside module `Foo`, the top of
+Modules can "use" other modules to import their **public** types, scopes and
+constants.
+
+~~~admonish bug title="Catala pretends it doesn't know the types I'm importing, what to do?"
+Often, this kind of error messages comes from the fact that you are trying
+to import a private type from an external module. See [Public and private objects](./5-6-modules.md#public-and-private-objects)
+below to know how to make your types public and usable as imports.
+~~~
+
+If you want to use module `Bar` inside module `Foo`, the top of
 `foo.catala_en` should look like:
 
 ```catala-en

--- a/src/en/5-6-modules.md
+++ b/src/en/5-6-modules.md
@@ -35,7 +35,7 @@ constants.
 
 ~~~admonish bug title="Catala pretends it doesn't know the types I'm importing, what to do?"
 Often, this kind of error messages comes from the fact that you are trying
-to import a private type from an external module. See [Public and private objects](./5-6-modules.md#public-and-private-objects)
+to import a private type from another module. See [Public and private objects](./5-6-modules.md#public-and-private-objects)
 below to know how to make your types public and usable as imports.
 ~~~
 

--- a/src/en/5-6-modules.md
+++ b/src/en/5-6-modules.md
@@ -30,8 +30,7 @@ you will not be able to call functions of this file from other modules.
 
 ## Imports
 
-Modules can "use" other modules to import their public types, scopes and
-constants. If you want to use module `Bar` inside module `Foo`, the top of
+Modules can "use" other modules to import their **public** types, scopes and constants. If you want to use module `Bar` inside module `Foo`, the top of
 `foo.catala_en` should look like:
 
 ```catala-en
@@ -64,6 +63,35 @@ type, so that for example you can refer to the type `Period` directly.
 
 This behaviour is disabled when the module name is aliased with `Using ... as`.
 ~~~
+
+### Public and private objects
+
+The Catala team believes that programmers should control precisely which interface they
+make publicly available for their modules. Indeed, not exposing internal
+functions is the key the preserve the ability to refactor the code later
+without breaking the endpoints used by the clients of the module.
+
+This is the reason why in Catala, all the type, scope and constant declarations
+inside `` ```catala `` blocks are private: they will not be accessible by other
+modules. To make a type, scope or constant declaration public and therefore
+accessible by other modules, you need to turn the containing `` ```catala ``
+block into a `` ```catala-metadata `` block. That's all!
+
+```catala-en
+> Module Bar
+
+```catala
+declaration structure Buzz ## default, only usable in this file
+  ....
+
+
+```catala-metadata
+declaration structure Fizz ## can be called in another module
+...
+
+```
+
+
 
 ## Inclusions
 
@@ -99,15 +127,5 @@ backends.
 What comes after the `Include:` is actually a Unix-style file path, that can
 refer to sub-directories or the parent directory (`../`).
 
-## Public interface and visibility
 
-The Catala team believes that programmers should control precisely which interface they
-make publicly available for their modules. Indeed, not exposing internal
-functions is the key the preserve the ability to refactor the code later
-without breaking the endpoints used by the clients of the module.
 
-This is the reason why in Catala, all the type, scope and constant declarations
-inside `` ```catala `` blocks are private: they will not be accessible by other
-modules. To make a type, scope or constant declaration public and therefore
-accessible by other modules, you need to turn the containing `` ```catala ``
-block into a `` ```catala-metadata `` block. That's all!

--- a/src/fr/5-6-modules.md
+++ b/src/fr/5-6-modules.md
@@ -31,7 +31,16 @@ vous ne pourrez pas appeler les fonctions de ce fichier depuis d'autres modules.
 ## Imports
 
 Les modules peuvent "utiliser" d'autres modules pour importer leurs types, champs d'application et
-constantes publics. Si vous voulez utiliser le module `Bar` à l'intérieur du module `Foo`, le haut de
+constantes **publics**.
+
+~~~admonish bug title="Catala n'arrive pas à trouver les types que j'importe, que faire ?"
+Souvent, ce genre de messages d'erreurs vient du fait que vous essayez d'importer
+un type privé depuis un autre module. Voir [Objets publics ou privés](./5-6-modules.md#objets-publics-ou-priv%C3%A9s)
+ci-dessous pour savoir comment rendre vos types publics et utilisables comme
+imports.
+~~~
+
+Si vous voulez utiliser le module `Bar` à l'intérieur du module `Foo`, le haut de
 `foo.catala_fr` devrait ressembler à :
 
 ```catala-fr
@@ -68,6 +77,18 @@ Cette possibilité est désactivée si le nom du module a été aliasé (en util
 `en tant que`).
 ~~~
 
+## Objets publics ou privés
+
+L'équipe Catala pense que les programmeurs devraient contrôler précisément quelle interface ils
+rendent publiquement disponible pour leurs modules. En effet, ne pas exposer les fonctions internes
+est la clé pour préserver la capacité de refactoriser le code plus tard
+sans casser les points de terminaison utilisés par les clients du module.
+
+C'est la raison pour laquelle en Catala, toutes les déclarations de type, de champ d'application et de constante
+à l'intérieur des blocs `` ```catala `` sont privées : elles ne seront pas accessibles par d'autres
+modules. Pour rendre une déclaration de type, de champ d'application ou de constante publique et donc
+accessible par d'autres modules, vous devez transformer le bloc `` ```catala ``
+contenant en un bloc `` ```catala-metadata ``. C'est tout !
 
 ## Inclusions
 
@@ -102,15 +123,3 @@ sont imprimées dans les backends de [programmation littéraire](./5-1-literate-
 Ce qui vient après `Inclusion:` est en fait un chemin de fichier de style Unix, qui peut
 faire référence à des sous-répertoires ou au répertoire parent (`../`).
 
-## Interface publique et visibilité
-
-L'équipe Catala pense que les programmeurs devraient contrôler précisément quelle interface ils
-rendent publiquement disponible pour leurs modules. En effet, ne pas exposer les fonctions internes
-est la clé pour préserver la capacité de refactoriser le code plus tard
-sans casser les points de terminaison utilisés par les clients du module.
-
-C'est la raison pour laquelle en Catala, toutes les déclarations de type, de champ d'application et de constante
-à l'intérieur des blocs `` ```catala `` sont privées : elles ne seront pas accessibles par d'autres
-modules. Pour rendre une déclaration de type, de champ d'application ou de constante publique et donc
-accessible par d'autres modules, vous devez transformer le bloc `` ```catala ``
-contenant en un bloc `` ```catala-metadata ``. C'est tout !


### PR DESCRIPTION
Quick suggestion following my mistake related to a missing catala-metadata. 

I put the "visibility" section as a subsection of import to emphasize that if one wants to import an object from another module it must first be declared as public.

(my experience : I had read the doc but focused on the import part, seeing that the inclusion didn't seem relevant to me and the visibility part didn't catch my attention because I only scanned it and the metadata keyword made me think it wasn't related to my current problem)

I would also suggest adding a link in the [Clerk project example](https://book.catala-lang.org/en/3-1-directory-config.html#clerk-project-example) to a functional example repo using the code from the tutorial. Does it seems relevant to you ? When debugging, I went to look at [catala-examples]( https://github.com/CatalaLang/catala-examples) but since the structure is quite more complex I didn't identify the simple info I needed.