### PR TITLE
Use catala nightly in CI, trigger build monthly, add missing clerk commands

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,10 +68,10 @@ jobs:
       - uses: baptiste0928/cargo-install@v3
         with:
           crate: tree-sitter-cli
-      - name: Download catala
-        uses: wei/wget@v1
-        with:
-          args: https://github.com/CatalaLang/catala/releases/download/1.0.0/catala_1.0.0_amd64.deb -O catala.deb
+      - name: Download catala nightly
+        run: gh release download nightly --repo CatalaLang/catala --pattern '*_amd64.deb' --output catala.deb
+        env:
+          GH_TOKEN: ${{ github.token }}
       - name: Install catala
         run: sudo dpkg -i ./catala.deb || true
       - uses: actions/checkout@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches: ["main", "master"]
   workflow_dispatch:
+  # Monthly run on the 2nd to keep manpages current against the catala nightly
+  schedule:
+    - cron: '0 6 2 * *'
 
 permissions:
   contents: read

--- a/src/en/6-2-commands-workflow.md
+++ b/src/en/6-2-commands-workflow.md
@@ -249,3 +249,59 @@ pipeline.
 <!-- cmdrun clerk clean --help=plain -->
 </pre>
 ```
+
+## `clerk typecheck`
+
+Type-checks the given Catala files and their dependencies without running them.
+Useful to validate a project quickly without executing any scope.
+
+```admonish info collapsible=true title="clerk typecheck &dash;&dash;help"
+<pre>
+<!-- cmdrun clerk typecheck --help=plain -->
+</pre>
+```
+
+## `clerk start`
+
+Prepares the local build environment with the Catala runtime and standard library.
+Not needed before other `clerk` commands, but useful before invoking the `catala`
+compiler directly.
+
+```admonish info collapsible=true title="clerk start &dash;&dash;help"
+<pre>
+<!-- cmdrun clerk start --help=plain -->
+</pre>
+```
+
+## `clerk exceptions`
+
+Prints the exception tree for the definitions of a particular variable in a scope.
+Useful for understanding and debugging complex exception hierarchies.
+
+```admonish info collapsible=true title="clerk exceptions &dash;&dash;help"
+<pre>
+<!-- cmdrun clerk exceptions --help=plain -->
+</pre>
+```
+
+## `clerk json-schema`
+
+Displays the JSON schema for the input and output objects of a given scope.
+See also the [JSON support](./5-8-3-json-support.md) section.
+
+```admonish info collapsible=true title="clerk json-schema &dash;&dash;help"
+<pre>
+<!-- cmdrun clerk json-schema --help=plain -->
+</pre>
+```
+
+## `clerk list-vars`
+
+Lists the pre-defined build variables that can be overridden with the `--vars`
+flag or in the `[variables]` section of `clerk.toml`.
+
+```admonish info collapsible=true title="clerk list-vars &dash;&dash;help"
+<pre>
+<!-- cmdrun clerk list-vars --help=plain -->
+</pre>
+```

--- a/src/fr/6-2-commands-workflow.md
+++ b/src/fr/6-2-commands-workflow.md
@@ -247,3 +247,59 @@ un travail CI ou pour s'assurer que vous n'incluez pas de fichiers périmés et 
 <!-- cmdrun clerk clean --help=plain -->
 </pre>
 ```
+
+## `clerk typecheck`
+
+Vérifie le typage des fichiers Catala donnés et de leurs dépendances sans les exécuter.
+Utile pour valider rapidement un projet sans exécuter de scope.
+
+```admonish info collapsible=true title="clerk typecheck &dash;&dash;help"
+<pre>
+<!-- cmdrun clerk typecheck --help=plain -->
+</pre>
+```
+
+## `clerk start`
+
+Prépare l'environnement de construction local avec le runtime et la bibliothèque
+standard de Catala. Non nécessaire avant les autres commandes `clerk`, mais utile
+avant d'invoquer directement le compilateur `catala`.
+
+```admonish info collapsible=true title="clerk start &dash;&dash;help"
+<pre>
+<!-- cmdrun clerk start --help=plain -->
+</pre>
+```
+
+## `clerk exceptions`
+
+Affiche l'arbre des exceptions pour les définitions d'une variable particulière
+dans un scope. Utile pour comprendre et déboguer des hiérarchies d'exceptions complexes.
+
+```admonish info collapsible=true title="clerk exceptions &dash;&dash;help"
+<pre>
+<!-- cmdrun clerk exceptions --help=plain -->
+</pre>
+```
+
+## `clerk json-schema`
+
+Affiche le schéma JSON des objets d'entrée et de sortie d'un scope donné.
+Voir aussi la section [support JSON](./5-8-3-json-support.md).
+
+```admonish info collapsible=true title="clerk json-schema &dash;&dash;help"
+<pre>
+<!-- cmdrun clerk json-schema --help=plain -->
+</pre>
+```
+
+## `clerk list-vars`
+
+Liste les variables de construction prédéfinies qui peuvent être redéfinies avec
+l'option `--vars` ou dans la section `[variables]` de `clerk.toml`.
+
+```admonish info collapsible=true title="clerk list-vars &dash;&dash;help"
+<pre>
+<!-- cmdrun clerk list-vars --help=plain -->
+</pre>
+```


### PR DESCRIPTION
## Summary

- Replaces the pinned `catala 1.0.0` download in the build CI with the latest nightly `.deb`, using `gh release download` to handle the dynamic asset filename. `dpkg -i || true` is preserved intentionally: the package has Debian-specific OCaml dep declarations that fail on Ubuntu, but the binary itself only needs `libgmp` and libc which are present.
- Adds a monthly schedule trigger (`0 6 2 * *`) to `deploy.yml` so manpages stay current even without book changes.
- Documents the following `clerk` commands that were missing from the reference chapter (EN + FR): `typecheck`, `start`, `exceptions`, `json-schema`, `list-vars`.

Closes #68
