### PR TITLE
add example for optional

### DIFF
--- a/src/en/5-2-types.md
+++ b/src/en/5-2-types.md
@@ -372,13 +372,32 @@ declaration enumeration OptionalInteger:
 ```
 
 But the advantage of `optional of integer` over such an `OptionalInteger` is
-that doesn't need to be declared for each type that it is used with. Like an
-enumeration, values of type `optional` can be created using `Present content
+that doesn't need to be declared for each type that it is used with. 
+
+Like an enumeration, values of type `optional` can be created using `Present content
 <expr>`, and used in the forms `match <expr> with pattern` and `<expr> with
-pattern <constr>`, e.g.
+pattern <constr>`, e.g. (see above the Enumeration section for more details)
 
 ```catala-expr-en
-if foo with pattern Present of bar and bar > 3 then ...
+declaration structure Tree:
+  data fruit content optional of Fruit
+
+Tree { 
+  -- fruit: Absent
+}
+
+Tree {
+  -- fruit: Present content Fruit { -- edible: false}
+}
+
+definition food equals
+  match tree.fruit with pattern
+    -- Absent: false
+    -- Present content fruit_present : fruit_present.edible
+
+if tree.fruit with pattern Present content fruit_present and fruit_present.edible 
+then ...
+else ...
 ```
 
 ## Functions

--- a/src/en/5-2-types.md
+++ b/src/en/5-2-types.md
@@ -372,32 +372,34 @@ declaration enumeration OptionalInteger:
 ```
 
 But the advantage of `optional of integer` over such an `OptionalInteger` is
-that doesn't need to be declared for each type that it is used with. 
+that doesn't need to be declared for each type that it is used with.
 
 Like an enumeration, values of type `optional` can be created using `Present content
 <expr>`, and used in the forms `match <expr> with pattern` and `<expr> with
-pattern <constr>`, e.g. (see above the Enumeration section for more details)
+pattern <constr>`, e.g. (see [Enumeration](./5-2-types.md#enumerations) for more details)
 
 ```catala-expr-en
 declaration structure Tree:
   data fruit content optional of Fruit
 
-Tree { 
+declaration no_fruit content Tree equals Tree {
   -- fruit: Absent
 }
 
-Tree {
+declaration nonedible_fruit content Tree equals Tree {
   -- fruit: Present content Fruit { -- edible: false}
 }
 
-definition food equals
-  match tree.fruit with pattern
+declaration food content boolean depends on tree content Tree equals
+  let a equals match tree.fruit with pattern
     -- Absent: false
     -- Present content fruit_present : fruit_present.edible
-
-if tree.fruit with pattern Present content fruit_present and fruit_present.edible 
-then ...
-else ...
+  in
+  let b equals
+    tree.fruit with pattern Present content fruit_present and
+      fruit_present.edible
+  in
+  a and b
 ```
 
 ## Functions

--- a/src/fr/5-2-types.md
+++ b/src/fr/5-2-types.md
@@ -366,13 +366,31 @@ déclaration énumération EntierOptionnel:
 ```
 
 Mais l'avantage de `optionnel de entier` par rapport à un tel `EntierOptionnel` est
-qu'il n'a pas besoin d'être déclaré pour chaque type avec lequel il est utilisé. Comme une
-énumération, les valeurs de type `optionnel` peuvent être créées en utilisant `Présent contenu
-<expr>`, et utilisées dans les formes `selon <expr> sous forme` et `<expr> sous
-forme <constr>`, par ex.
+qu'il n'a pas besoin d'être déclaré pour chaque type avec lequel il est utilisé. 
+
+Comme une énumération, les valeurs de type `optionnel` peuvent être créées en utilisant `Présent contenu <expr>`, et utilisées dans les formes `selon <expr> sous forme` et `<expr> sous forme <constr>`, par ex (voir ci-dessus section Enumération pour plus de détails)
 
 ```catala-expr-fr
-si foo sous forme Présent de bar et bar > 3 alors ...
+
+déclaration structure Arbre:
+  donnée fruit contenu optionel de Fruit
+
+Arbre { 
+  -- fruit: Absent
+}
+
+Arbre {
+  -- fruit: Présent contenu Fruit { -- comestible: faux}
+}
+
+définition nourriture égal à
+  selon arbre.fruit sous forme
+    -- Absent: faux
+    -- Présent contenu fruit_présent : fruit_présent.comestible
+
+si fruit sous forme Présent contenu fruit_présent et fruit_présent.comestible
+alors ...
+sinon ...
 ```
 
 ## Fonctions

--- a/src/fr/5-2-types.md
+++ b/src/fr/5-2-types.md
@@ -366,31 +366,35 @@ déclaration énumération EntierOptionnel:
 ```
 
 Mais l'avantage de `optionnel de entier` par rapport à un tel `EntierOptionnel` est
-qu'il n'a pas besoin d'être déclaré pour chaque type avec lequel il est utilisé. 
+qu'il n'a pas besoin d'être déclaré pour chaque type avec lequel il est utilisé.
 
-Comme une énumération, les valeurs de type `optionnel` peuvent être créées en utilisant `Présent contenu <expr>`, et utilisées dans les formes `selon <expr> sous forme` et `<expr> sous forme <constr>`, par ex (voir ci-dessus section Enumération pour plus de détails)
+Comme une énumération, les valeurs de type `optionnel` peuvent être créées en
+utilisant `Présent contenu <expr>`, et utilisées dans les formes `selon <expr>
+sous forme` et `<expr> sous forme <constr>`, par ex (voir [Enumération](./5-2-types.md#énumérations)
+ pour plus de détails)
 
 ```catala-expr-fr
 
 déclaration structure Arbre:
   donnée fruit contenu optionel de Fruit
 
-Arbre { 
+déclaration pas_de_fruit contenu Arbre égal à Arbre {
   -- fruit: Absent
 }
 
-Arbre {
+déclaration fruit_non_comestible contenu Arbre égal à Arbre {
   -- fruit: Présent contenu Fruit { -- comestible: faux}
 }
 
-définition nourriture égal à
-  selon arbre.fruit sous forme
+déclaration nourriture contenu booléen dépend de arbre contenu Arbre égal à
+  soit a égal à selon arbre.fruit sous forme
     -- Absent: faux
     -- Présent contenu fruit_présent : fruit_présent.comestible
-
-si fruit sous forme Présent contenu fruit_présent et fruit_présent.comestible
-alors ...
-sinon ...
+  dans
+  soit b égal à
+    fruit sous forme Présent contenu fruit_présent et fruit_présent.comestible
+  dans
+  a et b
 ```
 
 ## Fonctions


### PR DESCRIPTION
I added a few examples in the "optional" section for easier reference.

I removed this section :
```catala-expr-fr
si foo sous forme Présent de bar et bar > 3 alors ...
```
because I couldn't make it work (cf screenshot below). It seems to be ``Présent contenu bar`` instead of  ``Présent de bar`` ? or did I miss something ?

<img width="2012" height="884" alt="erreur_present_de" src="https://github.com/user-attachments/assets/7536be5e-ca18-4d37-8e7d-bec8bcaf6a9d" />
