### PR TITLE
fix: rename enumeration TaxCredit type (was shadowing its own case)

### DIFF
--- a/src/en/5-2-types.md
+++ b/src/en/5-2-types.md
@@ -280,10 +280,11 @@ declaration enumeration TaxCredit:
   -- TaxCreditAfterDate content date
 ```
 
-
-The type of each case of the enumeration is mandatory and introduced by
-`content`. It is possible to nest enumerations (declaring the type of a field of
-an enumeration as another enumeration or structure), but not recursively.
+Enumeration cases can have a value (called payload) or not. The payload of an
+enumeration case should be declared along with the case, the type of the payload
+is introduced by `content`. It is possible to nest enumerations (declaring the
+type of a field of an enumeration as another enumeration or structure), but not
+recursively.
 
 Enumeration values are built with the following syntax:
 

--- a/src/en/5-2-types.md
+++ b/src/en/5-2-types.md
@@ -274,7 +274,7 @@ chosen by the user. Enumeration names begin by a capital letter and should follo
 the `CamlCase` naming convention. An example of enumeration declaration is:
 
 ```catala-code-en
-declaration enumeration NoTaxCredit:
+declaration enumeration TaxCredit:
   -- NoTaxCredit
   -- TaxCreditForIndividual content Individual
   -- TaxCreditAfterDate content date

--- a/src/fr/5-2-types.md
+++ b/src/fr/5-2-types.md
@@ -276,7 +276,7 @@ choisi par l'utilisateur. Les noms d'énumération commencent par une majuscule 
 la convention de nommage `CamelCase`. Un exemple de déclaration d'énumération est :
 
 ```catala-code-fr
-déclaration énumération PasDeCreditImpot:
+déclaration énumération CreditImpot:
   -- PasDeCreditImpot
   -- CreditImpotPourIndividu contenu Individu
   -- CreditImpotApresDate contenu date

--- a/src/fr/5-2-types.md
+++ b/src/fr/5-2-types.md
@@ -282,10 +282,11 @@ déclaration énumération CreditImpot:
   -- CreditImpotApresDate contenu date
 ```
 
-
-Le type de chaque cas de l'énumération est obligatoire et introduit par
-`contenu`. Il est possible d'imbriquer des énumérations (déclarer le type d'un champ d'une
-énumération comme une autre énumération ou structure), mais pas récursivement.
+Les cas d'énumération peuvent contenir une valeur, ou pas. La valeur d'un cas
+d'énumération doit être déclarée avec le cas, son type est introduit par
+`contenu`. Il est possible d'imbriquer des énumérations (déclarer le type d'un
+champ d'une énumération comme une autre énumération ou structure), mais pas
+récursivement.
 
 Les valeurs d'énumération sont construites avec la syntaxe suivante :
 


### PR DESCRIPTION
NoTaxCredit duplicates one of its constructors, making the enum name misleading — should be TaxCredit to represent the sum type.